### PR TITLE
Add optional Chrome DevTools Protocol (CDP) support per display

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
     jq \
     dbus-x11 \
     x11-xserver-utils \
+    socat \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -42,10 +43,10 @@ LABEL \
     io.hass.name="VNC Web Browser" \
     io.hass.description="Display multiple web pages through VNC" \
     io.hass.type="addon" \
-    io.hass.version="0.11.0" \
+    io.hass.version="0.13.0" \
     io.hass.arch="aarch64|amd64|armhf|armv7"
 
-# Expose 8 sequential ports
-EXPOSE 5901/tcp 5902/tcp 5903/tcp 5904/tcp
+# Expose VNC ports (one per display) and optional CDP ports (Chrome DevTools Protocol)
+EXPOSE 5901/tcp 5902/tcp 5903/tcp 5904/tcp 9221/tcp 9222/tcp 9223/tcp 9224/tcp
 
 CMD ["/home/vnc_user/startup.sh"]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,36 @@ vnc_password: "your_secure_password"
     - `"--force-device-scale-factor=1.5"` - Set custom zoom level
     - `"--disable-features=Translate"` - Disable specific features
     - You can combine multiple arguments: `"--force-dark-mode --force-device-scale-factor=1.25"`
+  - `cdp_port`: Optional integer (9221-9224) enabling Chrome DevTools Protocol on this display. See "Chrome DevTools Protocol" below.
 - `vnc_password`: Password for VNC connections (required)
+
+## Chrome DevTools Protocol (CDP)
+
+Setting `cdp_port` on a display exposes Chromium's DevTools Protocol so external tools (Playwright, Puppeteer, browser automation agents) can drive the same browser session a user is watching over VNC. This is useful for AI agents that need a "teach me" mode where a human can take over via VNC mid-session.
+
+Example:
+
+```yaml
+displays:
+  - url: "https://example.com"
+    resolution: "1280x720"
+    port: 5901
+    cdp_port: 9222
+```
+
+Then connect from Playwright:
+
+```python
+browser = await playwright.chromium.connect_over_cdp("ws://<addon-host>:9222")
+```
+
+`<addon-host>` is either the addon's internal hostname (e.g. `<repo-hash>-vnc-web-browser` for sibling addons on the hassio Docker network) or your Home Assistant host's LAN IP if you publish the port externally.
+
+### Why CDP needs special handling
+
+Chromium M113+ silently ignores `--remote-debugging-address=0.0.0.0` and binds 127.0.0.1 regardless (upstream marked WontFix: [crbug.com/40261787](https://issues.chromium.org/issues/40261787)). The addon works around this by binding Chromium to a loopback-only internal port and forwarding via `socat` so the CDP endpoint is reachable from outside the container. The `--remote-allow-origins=*` flag is also injected automatically — without it, modern Chromium rejects WebSocket upgrades from non-localhost callers with a 403.
+
+Do **not** put `--remote-debugging-port` or `--remote-debugging-address` into `browser_args` when using `cdp_port`; those flags are stripped automatically to prevent collisions.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ browser = await playwright.chromium.connect_over_cdp("ws://<addon-host>:9222")
 
 `<addon-host>` is either the addon's internal hostname (e.g. `<repo-hash>-vnc-web-browser` for sibling addons on the hassio Docker network) or your Home Assistant host's LAN IP if you publish the port externally.
 
+Do not publish cdp_port to a host port on an untrusted network — CDP has no authentication.
+
 ### Why CDP needs special handling
 
 Chromium M113+ silently ignores `--remote-debugging-address=0.0.0.0` and binds 127.0.0.1 regardless (upstream marked WontFix: [crbug.com/40261787](https://issues.chromium.org/issues/40261787)). The addon works around this by binding Chromium to a loopback-only internal port and forwarding via `socat` so the CDP endpoint is reachable from outside the container. The `--remote-allow-origins=*` flag is also injected automatically — without it, modern Chromium rejects WebSocket upgrades from non-localhost callers with a 403.

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 name: "VNC Web Browser"
-version: "0.12.0"
+version: "0.13.0"
 slug: "vnc_web_browser"
-description: "Display multiple web pages through VNC"
+description: "Display multiple web pages through VNC, with optional Chrome DevTools Protocol access"
 url: "https://github.com/mindfreeze/ha-vnc-web-browser"
 arch:
   - aarch64
@@ -17,11 +17,19 @@ ports:
   5902/tcp: 5902
   5903/tcp: 5903
   5904/tcp: 5904
+  9221/tcp: null
+  9222/tcp: null
+  9223/tcp: null
+  9224/tcp: null
 ports_description:
   5901/tcp: "VNC port for display 1"
   5902/tcp: "VNC port for display 2"
   5903/tcp: "VNC port for display 3"
   5904/tcp: "VNC port for display 4"
+  9221/tcp: "Chrome DevTools Protocol (optional — set cdp_port on a display)"
+  9222/tcp: "Chrome DevTools Protocol (optional — set cdp_port on a display)"
+  9223/tcp: "Chrome DevTools Protocol (optional — set cdp_port on a display)"
+  9224/tcp: "Chrome DevTools Protocol (optional — set cdp_port on a display)"
 schema:
   displays:
     - url: str?
@@ -30,6 +38,7 @@ schema:
       depth: int(8,32)?
       view_only: bool?
       browser_args: str?
+      cdp_port: int(9221,9224)?
   vnc_password: password?
 options:
   displays:

--- a/run_vnc.sh
+++ b/run_vnc.sh
@@ -19,7 +19,25 @@ while IFS= read -r display; do
     depth=$(echo $display | jq -r '.depth // 16')
     view_only=$(echo $display | jq -r '.view_only // false')
     browser_args=$(echo $display | jq -r '.browser_args // ""')
+    cdp_port=$(echo $display | jq -r '.cdp_port // empty')
     display_number=$((port - 5900))
+
+    # Chrome DevTools Protocol setup.
+    # Chromium M113+ silently ignores --remote-debugging-address=0.0.0.0 and binds
+    # 127.0.0.1 (upstream WontFix: crbug.com/40261787). We work around it by binding
+    # Chromium to an internal loopback port and forwarding via socat so the CDP
+    # endpoint is reachable from sibling addons / the host.
+    if [ -n "$cdp_port" ]; then
+        internal_cdp_port=$((cdp_port + 100))
+        # Strip any user-supplied remote-debugging flags to avoid port collisions
+        browser_args=$(echo "$browser_args" | sed -E 's/--remote-debugging-port=[^ ]*//g; s/--remote-debugging-address=[^ ]*//g; s/--remote-allow-origins=[^ ]*//g')
+        # Append our managed CDP flags. --remote-allow-origins is required for
+        # WebSocket upgrades from non-localhost callers (Playwright, Puppeteer, etc).
+        browser_args="$browser_args --remote-debugging-port=$internal_cdp_port --remote-allow-origins=*"
+        # Forwarder: external 0.0.0.0:$cdp_port -> chromium 127.0.0.1:$internal_cdp_port
+        echo "Starting CDP forwarder for display $display_number: 0.0.0.0:$cdp_port -> 127.0.0.1:$internal_cdp_port"
+        socat TCP4-LISTEN:$cdp_port,fork,reuseaddr,bind=0.0.0.0 TCP4:127.0.0.1:$internal_cdp_port &
+    fi
 
     # Split resolution into width and height
     width=$(echo $resolution | cut -d'x' -f1)


### PR DESCRIPTION
## Summary

Adds an optional `cdp_port` field per display that exposes Chromium's Chrome DevTools Protocol so external tools (Playwright, Puppeteer, browser automation agents, AI agents) can drive the same browser session that a human is observing over VNC. Off by default.

The motivating use case: agentic browser automation on Home Assistant OS. The agent needs CDP; the human needs VNC to watch and occasionally take over (captchas, teaching). This addon already nails the VNC + persistent-profile side beautifully — CDP is the natural complement.

## Why this isn't just `--remote-debugging-port=9222` in `browser_args`

Since Chromium M113, `--remote-debugging-address=0.0.0.0` is silently downgraded to `127.0.0.1` as a security hardening measure (upstream WontFix: [crbug.com/40261787](https://issues.chromium.org/issues/40261787)). The flag passes through but the binding is loopback-only, so nothing outside the container can reach CDP — even when you publish 9222 in `config.yaml`, the host-side port forward points at a closed socket.

This PR works around it the same way every Chromium-in-container project does (Browserless, Playwright Docker, etc.): bind Chromium to a loopback-only internal port, then forward `0.0.0.0:cdp_port → 127.0.0.1:internal` via `socat`. `--remote-allow-origins=*` is also injected — without it, modern Chromium rejects WebSocket upgrades from non-localhost callers with a 403, which silently breaks Playwright/Puppeteer (HTTP `/json/version` works, WS doesn't).

## Changes

- **Dockerfile**: install `socat`; expose 9221-9224.
- **config.yaml**: add 9221-9224 to `ports:` (defaulted to `null` so they're reachable from sibling addons but not published to the host unless explicitly configured); add `cdp_port: int(9221,9224)?` to the per-display schema; bump version to 0.13.0.
- **run_vnc.sh**: when `cdp_port` is set on a display, strip any conflicting `--remote-debugging-*` flags from user-supplied `browser_args`, inject `--remote-debugging-port=<internal>` (= `cdp_port + 100`) and `--remote-allow-origins=*`, and launch a `socat` forwarder.
- **README**: document `cdp_port` and explain the M113+ workaround.

## Backwards compatibility

Fully backwards compatible. Existing configs without `cdp_port` behave identically — no socat is launched, no flags injected. Users who previously put `--remote-debugging-port=9222` into `browser_args` (which didn't actually work because of M113+) will see those flags silently stripped if they also set `cdp_port`, which is the safer behavior.

## Test plan

- [ ] Build passes CI (docker build)
- [ ] Existing displays without `cdp_port` still work (no socat, no extra flags)
- [ ] With `cdp_port: 9222`, `curl http://<addon-host>:9222/json/version` returns Chromium build info
- [ ] Playwright `connect_over_cdp("ws://<addon-host>:9222")` connects successfully (verifies `--remote-allow-origins`)
- [ ] Multiple displays each get their own CDP port without collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)